### PR TITLE
Fixes #8 ch5 audio

### DIFF
--- a/CH5/hdl/pdm_inputs.sv
+++ b/CH5/hdl/pdm_inputs.sv
@@ -26,7 +26,8 @@ module pdm_inputs
 
   initial begin
     sample_counter = '0;
-    counter        = '0;
+    counter[0]     = '0;
+    counter[1]     = 8'd100;
     m_clk          = '0;
     clk_counter    = '0;
   end
@@ -41,7 +42,6 @@ module pdm_inputs
       m_clk_en    <= ~m_clk;
     end else begin
       clk_counter <= clk_counter + 1;
-      if (clk_counter == CLK_COUNT - 2) m_clk_en    <= ~m_clk;
     end
 
     if (m_clk_en) begin
@@ -52,15 +52,15 @@ module pdm_inputs
         amplitude         <= sample_counter[0];
         amplitude_valid   <= '1;
         sample_counter[0] <= '0;
-      end else if (counter[0] < 128) begin
+      end else if (counter[0] < 127) begin
         sample_counter[0] <= sample_counter[0] + m_data;
       end
-      if (counter[1] == 227) begin
+      if (counter[1] == 199) begin
         counter[1]        <= '0;
-        amplitude         <= sample_counter[1] + m_data;
+        amplitude         <= sample_counter[1];
         amplitude_valid   <= '1;
         sample_counter[1] <= '0;
-      end else if (counter[1] > 100) begin
+      end else if (counter[1] <127) begin
         sample_counter[1] <= sample_counter[1] + m_data;
       end
     end

--- a/CH5/tb/tb_pdm.sv
+++ b/CH5/tb/tb_pdm.sv
@@ -92,9 +92,9 @@ module tb_pdm;
     int_count <= int_count + 1'b1;
     if (&int_count) counter <= counter + 1'b1;
     if (counter > 127) begin
-      data_in <= ~sin_table[counter[6:0]] + 1'b1;
+      data_in <= 7'h40 - sin_table[counter[6:0]];
     end else begin
-      data_in <= sin_table[counter[6:0]];
+      data_in <= 7'h40 + sin_table[counter[6:0]];
     end
   end
 


### PR DESCRIPTION
This pull request should fix issue 8.
It fixes a problem with the test bench in which a sine wave should be generated.

The rest of the fix is in the sampling of the m_data signal:
1. Time between assertion of the amplitude_valid signal due to counter[0] and counter[1] was not constant. That is fixed by having both counter[0] and counter[1] behave exactly the same, and giving counter[1] an initial offset.
2. m_data is added to sample_counter in 128 ticks of m_clk (m_clk_en asserted, posedge clk). In case m_data is 1 during all 128 ticks, the 7-bit sample_counter will overflow and this results in a dip in the amplitude signal (see images in the issue). This is fixed by sampling only during 127 ticks.